### PR TITLE
fix: correct typing of FetchError

### DIFF
--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -298,7 +298,7 @@ export type SystemError = {
 };
 
 export class FetchError extends FetchBaseError {
-  code: number;
+  code: string;
   erroredSysCall?: SystemError;
 }
 


### PR DESCRIPTION
FetchError is being exported with the property `code` typed as a number when it is actually a `string`. This can break existing TypeScript projects that rely on type enforcement.

Fixes #386

Please ensure your pull request adheres to the following guidelines:
- [ X] make sure to link the related issues in this description
- [ X] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
