### PR TITLE
fix: correct exporting of Headers.raw

### DIFF
--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -105,7 +105,7 @@ export class Headers implements Iterable<[string, string]> {
   has(name: string): boolean;
   set(name: string, value: string): void;
 
-  raw(): Record<string, string[]>;
+  raw(): Record<string, string | string[]>;
   entries(): Iterator<[string, string]>;
   keys(): Iterator<string>;
   values(): Iterator<string>;

--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -105,6 +105,7 @@ export class Headers implements Iterable<[string, string]> {
   has(name: string): boolean;
   set(name: string, value: string): void;
 
+  raw(): Record<string, string[]>;
   entries(): Iterator<[string, string]>;
   keys(): Iterator<string>;
   values(): Iterator<string>;


### PR DESCRIPTION
The `Headers` class does not currently export the `raw` function as it should.

Please ensure your pull request adheres to the following guidelines:
- [ X] make sure to link the related issues in this description
- [ X] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

Fixes #388 

Thanks for contributing!
