### PR TITLE
fix: Add Response.clone() typedef (#406)

### DIFF
--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -145,6 +145,7 @@ export class Response extends Body {
   readonly httpVersion: string;
   readonly decoded: boolean;
   headers: Headers;
+  clone(): Response;
 
   // non-spec extensions
   /**


### PR DESCRIPTION
Addresses: #406

Adds Response.clone() to typescript definition.
https://developer.mozilla.org/en-US/docs/Web/API/Response/clone