### PR TITLE
Backport "Bypass alpn cache when alpn not negotiated" to 3.x

### DIFF
--- a/src/core/request.js
+++ b/src/core/request.js
@@ -123,11 +123,11 @@ const determineProtocol = async (ctx, url, signal) => {
     case 'http:':
       // for simplicity, we assume unencrypted HTTP to be HTTP/1.1
       // (although, theoretically, it could also be plain-text HTTP/2 (h2c))
-      return { ALPN_HTTP1_1 };
+      return { protocol: ALPN_HTTP1_1 };
 
     case 'http2:':
       // HTTP/2 over TCP (h2c)
-      return { ALPN_HTTP2C };
+      return { protocol: ALPN_HTTP2C };
 
     case 'https:':
       // need to negotiate protocol
@@ -140,7 +140,7 @@ const determineProtocol = async (ctx, url, signal) => {
   if (ctx.alpnProtocols.length === 1
     && (ctx.alpnProtocols[0] === ALPN_HTTP1_1 || ctx.alpnProtocols[0] === ALPN_HTTP1_0)) {
     // shortcut: forced HTTP/1.X, default to HTTP/1.1 (no need to use ALPN to negotiate protocol)
-    return { ALPN_HTTP1_1 };
+    return { protocol: ALPN_HTTP1_1 };
   }
 
   // lookup ALPN cache

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -118,24 +118,16 @@ const connect = async (url, options) => {
 const determineProtocol = async (ctx, url, signal) => {
   // url.origin is null if url.protocol is neither 'http:' nor 'https:' ...
   const origin = `${url.protocol}//${url.host}`;
-  // lookup ALPN cache
-  let protocol = ctx.alpnCache.get(origin);
-  if (protocol) {
-    return { protocol };
-  }
+
   switch (url.protocol) {
     case 'http:':
-      // for simplicity we assume unencrypted HTTP to be HTTP/1.1
+      // for simplicity, we assume unencrypted HTTP to be HTTP/1.1
       // (although, theoretically, it could also be plain-text HTTP/2 (h2c))
-      protocol = ALPN_HTTP1_1;
-      ctx.alpnCache.set(origin, protocol);
-      return { protocol };
+      return { ALPN_HTTP1_1 };
 
     case 'http2:':
       // HTTP/2 over TCP (h2c)
-      protocol = ALPN_HTTP2C;
-      ctx.alpnCache.set(origin, protocol);
-      return { protocol };
+      return { ALPN_HTTP2C };
 
     case 'https:':
       // need to negotiate protocol
@@ -148,12 +140,16 @@ const determineProtocol = async (ctx, url, signal) => {
   if (ctx.alpnProtocols.length === 1
     && (ctx.alpnProtocols[0] === ALPN_HTTP1_1 || ctx.alpnProtocols[0] === ALPN_HTTP1_0)) {
     // shortcut: forced HTTP/1.X, default to HTTP/1.1 (no need to use ALPN to negotiate protocol)
-    protocol = ALPN_HTTP1_1;
-    ctx.alpnCache.set(origin, protocol);
+    return { ALPN_HTTP1_1 };
+  }
+
+  // lookup ALPN cache
+  let protocol = ctx.alpnCache.get(origin);
+  if (protocol) {
     return { protocol };
   }
 
-  // negotioate via ALPN
+  // negotiate via ALPN
   const {
     options: {
       rejectUnauthorized: _rejectUnauthorized,


### PR DESCRIPTION
Addresses issue https://github.com/adobe/fetch/issues/431 - requesting this backport to 3.x

Backports: 
- ALPN cache bypass for connections not using alpn to 3.x branch
- The correction (thank you!) from @stefan-guggisberg 

## Related Issues
https://github.com/adobe/fetch/issues/410
